### PR TITLE
Fix issue #2 - ICE during compilation of javalib

### DIFF
--- a/gcc/cp/except.cc
+++ b/gcc/cp/except.cc
@@ -761,21 +761,21 @@ build_throw (location_t loc, tree exp)
 
   if (exp && decl_is_java_type (TREE_TYPE (exp), 1))
     {
-      tree fn = get_identifier ("_Jv_Throw");
+      tree name = get_identifier ("_Jv_Throw");
+      tree fn = get_global_binding (name);
       if (!fn)
        {
          /* Declare void _Jv_Throw (void *).  */
          tree tmp;
          tmp = build_function_type_list (ptr_type_node,
                                          ptr_type_node, NULL_TREE);
-         fn = push_throw_library_fn (fn, tmp);
+         fn = push_throw_library_fn (name, tmp);
        }
       else if (really_overloaded_fn (fn))
        {
          error ("%qD should never be overloaded", fn);
          return error_mark_node;
        }
-      fn = OVL_FIRST (TREE_VALUE (fn));
       exp = cp_build_function_call_nary (fn, tf_warning_or_error,
                                         exp, NULL_TREE);
     }

--- a/gcc/cp/init.cc
+++ b/gcc/cp/init.cc
@@ -3334,7 +3334,7 @@ build_new_1 (vec<tree, va_gc> **placement, tree type, tree nelts,
 
       use_java_new = 1;
 
-      if (!get_identifier (alloc_name))
+      if (!(alloc_fn = get_global_binding (get_identifier (alloc_name))))
 	{
           if (complain & tf_error)
             error ("call to Java constructor with %qs undefined", alloc_name);
@@ -3346,7 +3346,6 @@ build_new_1 (vec<tree, va_gc> **placement, tree type, tree nelts,
             error ("%qD should never be overloaded", alloc_fn);
 	  return error_mark_node;
 	}
-      alloc_fn = OVL_FIRST (TREE_VALUE (alloc_fn));
       if (TREE_CODE (alloc_fn) != FUNCTION_DECL
 	  || TREE_CODE (TREE_TYPE (alloc_fn)) != FUNCTION_TYPE
 	  || !POINTER_TYPE_P (TREE_TYPE (TREE_TYPE (alloc_fn))))


### PR DESCRIPTION
This a fix for issue #2.

A function call from the original code from GCC 6 was dropped by mistake.

In GCC 6 `get_global_value_if_present()` was used to fetch a symbol from
global scope. These are two links to what the original code looked like.

https://github.com/gcc-mirror/gcc/blob/releases/gcc-6.1.0/gcc/cp/init.c#L2854-L2855
https://github.com/gcc-mirror/gcc/blob/releases/gcc-6.1.0/gcc/cp/except.c#L743-L744

In GCC 12 the function used is `get_global_binding()`. for example:
https://github.com/gcc-mirror/gcc/blob/releases/gcc-12.1.0/gcc/cp/class.cc#L10011-L10018

This a test case for the fix:

file: `test.cc`
```cpp
#include <java/lang/Integer.h>

auto test () {
 return new java::lang::Integer(1);
}
```

prior to this fix:
```bash
./gcj-build/gcc/xgcc  -B./gcj-build/gcc -I./libjava -I./gcj-build/x86_64-pc-linux-gnu/libjava/ -Wextra -Wall -c test.cc

test.cc: In function 'auto test()':
test.cc:4:34: internal compiler error: Segmentation fault
    4 |  return new java::lang::Integer(1);
      |                                  ^
0x11b543f crash_signal
        ../../gcc/toplev.cc:322
0x7f40f7da651f ???
        ./signal/../sysdeps/unix/sysv/linux/x86_64/libc_sigaction.c:0
0xbd1224 location_wrapper_p(tree_node const*)
        ../../gcc/tree.h:4210
0xbd1224 tree_strip_any_location_wrapper(tree_node*)
        ../../gcc/tree.h:4222
0xbd1224 is_overloaded_fn(tree_node*)
        ../../gcc/cp/tree.cc:2565
0xbd1548 really_overloaded_fn(tree_node*)
        ../../gcc/cp/tree.cc:2607
0xa67f5a build_new_1
        ../../gcc/cp/init.cc:3343
0xa6a8d1 build_new(unsigned int, vec<tree_node*, va_gc, vl_embed>**, tree_node*, tree_node*, vec<tree_node*, va_gc, vl_embed>**, int, int)
        ../../gcc/cp/init.cc:4068
0xb24237 cp_parser_new_expression
        ../../gcc/cp/parser.cc:9307
0xb248a1 cp_parser_unary_expression
        ../../gcc/cp/parser.cc:8895
0xaf2cb6 cp_parser_binary_expression
        ../../gcc/cp/parser.cc:10043
0xaf383e cp_parser_assignment_expression
        ../../gcc/cp/parser.cc:10347
0xaf5379 cp_parser_expression
        ../../gcc/cp/parser.cc:10517
0xb0600e cp_parser_jump_statement
        ../../gcc/cp/parser.cc:14328
0xb0600e cp_parser_statement
        ../../gcc/cp/parser.cc:12323
0xb06d1d cp_parser_statement_seq_opt
        ../../gcc/cp/parser.cc:12883
0xb06df7 cp_parser_compound_statement
        ../../gcc/cp/parser.cc:12835
0xb27715 cp_parser_function_body
        ../../gcc/cp/parser.cc:25186
0xb27715 cp_parser_ctor_initializer_opt_and_function_body
        ../../gcc/cp/parser.cc:25237
0xb2861e cp_parser_function_definition_after_declarator
        ../../gcc/cp/parser.cc:31369
Please submit a full bug report, with preprocessed source (by using -freport-bug).
Please include the complete backtrace with any bug report.
See <https://gcc.gnu.org/bugs/> for instructions.
```

after this fix:
```bash
./gcj-build/gcc/xgcc  -B./gcj-build/gcc -I./libjava -I./gcj-build/x86_64-pc-linux-gnu/libjava/ -Wextra -Wall -c test.cc

echo $?
0
```