### PR TITLE
Master gjc 221223 driver fix

### DIFF
--- a/gcc/java/jvspec.cc
+++ b/gcc/java/jvspec.cc
@@ -57,7 +57,7 @@ int lang_specific_extra_outfiles = 0;
 int shared_libgcc = 1;
 
 static const char jvgenmain_spec[] =
-  "jvgenmain %{findirect-dispatch} %{D*} %b %m.i |\n\
+  "jvgenmain %{findirect-dispatch} %{D*} %w%b %m.i |\n\
    cc1 %m.i %1 \
      %{!Q:-quiet} -dumpbase %b.c %{d*} %{m*}\
      %{g*} %{O*} %I \

--- a/gcc/java/jvspec.cc
+++ b/gcc/java/jvspec.cc
@@ -59,26 +59,26 @@ int shared_libgcc = 1;
 static const char jvgenmain_spec[] =
   "jvgenmain %{findirect-dispatch} %{D*} %b %m.i |\n\
    cc1 %m.i %1 \
-		   %{!Q:-quiet} -dumpbase %b.c %{d*} %{m*}\
-		   %{g*} %{O*} %I \
-		   %{v:-version} %{pg:-p} %{p}\
-		   %<fbounds-check %<fno-bounds-check\
-		   %<fassume-compiled* %<fno-assume-compiled*\
-		   %<fcompile-resource* %<fassert %<fno-assert \
-		   %<femit-class-file %<femit-class-files %<fencoding*\
-		   %<fhash-synchronization %<fjni\
-		   %<findirect-dispatch\
-		   %<fno-store-check %<foutput-class-dir\
-		   %<fclasspath* %<fbootclasspath*\
-		   %<fextdirs*\
-		   %<fuse-divide-subroutine %<fno-use-divide-subroutine\
-		   %<fuse-atomic-builtins %<fno-use-atomic-builtins\
-		   %<fcheck-references %<fno-check-references\
-		   %<ffilelist-file %<fsaw-java-file %<fsource* %<ftarget*\
-		   %{f*} -fdollars-in-identifiers\
-		   %{aux-info*}\
-		   %{pg:%{fomit-frame-pointer:%e-pg and -fomit-frame-pointer are incompatible}}\
-		   %{S:%W{o*}%{!o*:-o %b.s}}\
+     %{!Q:-quiet} -dumpbase %b.c %{d*} %{m*}\
+     %{g*} %{O*} %I \
+     %{v:-version} %{pg:-p} %{p}\
+     %<fbounds-check %<fno-bounds-check\
+     %<fassume-compiled* %<fno-assume-compiled*\
+     %<fcompile-resource* %<fassert %<fno-assert \
+     %<femit-class-file %<femit-class-files %<fencoding*\
+     %<fhash-synchronization %<fjni\
+     %<findirect-dispatch\
+     %<fno-store-check %<foutput-class-dir\
+     %<fclasspath* %<fbootclasspath*\
+     %<fextdirs*\
+     %<fuse-divide-subroutine %<fno-use-divide-subroutine\
+     %<fuse-atomic-builtins %<fno-use-atomic-builtins\
+     %<fcheck-references %<fno-check-references\
+     %<ffilelist-file %<fsaw-java-file %<fsource* %<ftarget*\
+     %{f*} -fdollars-in-identifiers\
+     %{aux-info*}\
+     %{pg:%{fomit-frame-pointer:%e-pg and -fomit-frame-pointer are incompatible}}\
+     %{S:%W{o*}%{!o*:-o %b.s}}\
    %(invoke_as)";
 
 /* Return full path name of spec file if it is in DIR, or NULL if


### PR DESCRIPTION
with this fix, libjava builds and installs on x86_64 darwin, I had to build at O1 because of one ICE @O2.

however something is still not right because every built java program (even trivial ones) fails like this:

$ /opt/iains/x86_64-apple-darwin21/gcc-13-0-0/bin/gcj /source/test/java/HelloWorld.java --main=HelloWorld -o hw
libgcj failure: gcj linkage error.
Incorrect library ABI version detected.  Aborting.

gcj: internal compiler error: Abort trap: 6 signal terminated program ecj1
Please submit a full bug report, with preprocessed source (by using -freport-bug).
